### PR TITLE
ログ設定

### DIFF
--- a/knowde/api/middleware/error_handling/__init__.py
+++ b/knowde/api/middleware/error_handling/__init__.py
@@ -16,9 +16,9 @@ if TYPE_CHECKING:
 class ErrorHandlingMiddleware(BaseHTTPMiddleware):
     """fastapiでエラーを検出."""
 
-    @staticmethod
     @override
     async def dispatch(
+        self,
         request: Request,
         call_next: RequestResponseEndpoint,
     ) -> Response:

--- a/knowde/api/middleware/transaction.py
+++ b/knowde/api/middleware/transaction.py
@@ -76,7 +76,3 @@ def neo4j_logger() -> logging.Logger:
     )
     logger.addHandler(handler)
     return logger
-
-
-def set_error_handlers(app: FastAPI):
-    """独自のエラーハンドリング."""

--- a/knowde/feature/knowde/__init__.py
+++ b/knowde/feature/knowde/__init__.py
@@ -36,7 +36,11 @@ class Knowde(BaseModel, frozen=True):
     sentence: str
     uid: UUID
     term: Term | None = None
+
+    # additional
     when: str | None = None
+    where: str | None = None
+    by: str | None = None
 
     def __str__(self) -> str:  # noqa: D105
         t = f"[{self.term}]" if self.term else ""

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,3 +21,6 @@ env =
   NEO4J_URI=localhost
   NEO4J_URL=bolt://{NEO4J_USERNAME}:{NEO4J_PASSWORD}@{NEO4J_URI}:7687
   KNOWDE_URL=http://localhost:8000
+
+; log_format = %(asctime)s %(levelname)s %(message)s
+; log_date_format = %Y-%m-%d %H:%M:%S.%f


### PR DESCRIPTION
現状では
> 2025-07-14T06:59:25.189719066Z       INFO   xx.xx.xx.xx:0 - "GET /user/me HTTP/1.1" 401
のようなfastapiの初期の簡素なログ

誰がいつどういうリクエストとレスポンスだったのか
応答にかかった時間は？
エラーはどこで起きたか。エラーメッセージは？

などを記録するようにして運用に備えたい
