### PR TITLE
user update test & username 対応

### DIFF
--- a/knowde/feature/user/__init__.py
+++ b/knowde/feature/user/__init__.py
@@ -15,3 +15,4 @@ class CommonSchema(BaseModel):  # noqa: D101
     display_name: str | None = Field(default=None, max_length=LEN_DISPLAY_NAME)
     profile: str | None = Field(default=None, max_length=LEN_PROFILE)
     avatar_url: str | None = None
+    username: str | None = Field(default=None, pattern=r"^[^-]*$")

--- a/knowde/feature/user/manager.py
+++ b/knowde/feature/user/manager.py
@@ -41,6 +41,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     async def on_after_request_verify(self, user, token, request=None):
         logger.info("User has requested email verification. %s", user.id)
 
+    @override
+    async def on_after_update(self, user, update_dict, request=None):
+        logger.info("User has been updated. %s", update_dict)
+
 
 def get_user_manager() -> UserManager:
     """For fastapi-users."""

--- a/knowde/feature/user/repo/db.py
+++ b/knowde/feature/user/repo/db.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import override
 from uuid import UUID
 
@@ -14,7 +13,6 @@ from knowde.feature.user.domain import Account, User
 from knowde.feature.user.repo.label import LAccount
 from knowde.shared.labels.user import LUser
 from knowde.shared.types.mapper import label2model
-from knowde.shared.util import TZ
 
 
 class AccountDB(BaseUserDatabase[User, UUID]):
@@ -22,7 +20,6 @@ class AccountDB(BaseUserDatabase[User, UUID]):
 
     @override
     async def get(self, id):
-        """Get a single user by id."""
         # print("---------get")
         lb = await LUser.nodes.get_or_none(uid=id.hex)
         if lb is None:
@@ -31,7 +28,6 @@ class AccountDB(BaseUserDatabase[User, UUID]):
 
     @override
     async def get_by_email(self, email):
-        """Get a single user by email."""
         # print("---------get by email")
         lb = await LUser.nodes.get_or_none(email=email)
         if lb is None:
@@ -40,8 +36,6 @@ class AccountDB(BaseUserDatabase[User, UUID]):
 
     @override
     async def get_by_oauth_account(self, oauth, account_id):
-        """Get a single user by OAuth account id."""
-        # print("---------get by oauth")
         la = LAccount.nodes.get_or_none(account_id=account_id)
         if la is None:
             return None
@@ -50,7 +44,6 @@ class AccountDB(BaseUserDatabase[User, UUID]):
 
     @override
     async def create(self, create_dict):
-        """Create a user."""
         if await self.get_by_email(create_dict["email"]):
             raise  # noqa: PLE0704
         lb = await LUser(**create_dict).save()
@@ -58,20 +51,16 @@ class AccountDB(BaseUserDatabase[User, UUID]):
 
     @override
     async def update(self, user, update_dict):
-        """Update a user."""
-        # print("------------ update")
         lb = await LUser.nodes.get(uid=user.id)
-        for key, value in update_dict.items():
-            if value is None:
+        for k, v in update_dict.items():
+            if v is None:
                 continue
-            setattr(lb, key, value)
-        lb.created = datetime.now(tz=TZ)
+            setattr(lb, k, v)
         lb = await lb.save()
         return label2model(User, lb)
 
     @override
     async def delete(self, user):
-        """Delete a user."""
         # print("------------ delete")
         lb = await LUser.nodes.get(uid=user.id.hex)
         await lb.delete()
@@ -79,8 +68,6 @@ class AccountDB(BaseUserDatabase[User, UUID]):
     # OAUTH
     @override
     async def add_oauth_account(self, user, create_dict):
-        """Create an OAuth account and add it to the user."""
-        # print("------------ add oauth account")
         account = Account.model_validate(create_dict)
         la = account.tolabel().save()
         lu = await LUser.nodes.get(uid=user.id.hex)
@@ -89,6 +76,4 @@ class AccountDB(BaseUserDatabase[User, UUID]):
 
     @override
     async def update_oauth_account(self, user, oauth_account, update_dict):
-        """Update an OAuth account on a user."""
-        print("------------ update oauth account", user, update_dict)  # noqa: T201
         return user

--- a/knowde/feature/user/routers/repo/client.py
+++ b/knowde/feature/user/routers/repo/client.py
@@ -76,8 +76,14 @@ class AuthPatch(BaseModel):
         email: str | None = None,
         password: str | None = None,
         display_name: str | None = None,
+        user_id: str | None = None,
     ) -> httpx.Response:
-        d = {"email": email, "password": password, "display_name": display_name}
+        d = {
+            "email": email,
+            "password": password,
+            "display_name": display_name,
+            "id": user_id,
+        }
         d = {k: v for k, v in d.items() if v is not None}
         return self.client(f"{PREFIX_USER}/me", headers=auth_header(), json=d)
 

--- a/knowde/feature/user/routers/repo/test_client.py
+++ b/knowde/feature/user/routers/repo/test_client.py
@@ -54,7 +54,6 @@ def test_crud_user(client: TestClient) -> None:
 
     assert res.is_success
     assert res.json()["email"] == email2
-    assert res.json().get("created") != d
 
 
 # def test_update_additional(client: TestClient):

--- a/knowde/feature/user/routers/test_user_router.py
+++ b/knowde/feature/user/routers/test_user_router.py
@@ -1,0 +1,67 @@
+"""test user router."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from knowde.api import root_router
+from knowde.api.middleware.logging.log_config import ContextFilter, text_formatter
+from knowde.feature.user.schema import UserRead
+
+
+@pytest.mark.enable_app_logging
+def test_update_user(caplog: pytest.LogCaptureFixture):
+    """Patch user test."""
+    caplog.set_level("INFO")
+    handler = caplog.handler
+    handler.addFilter(ContextFilter())
+    handler.setFormatter(text_formatter())
+
+    client = TestClient(root_router())
+
+    email = "log@test.com"
+    pwd = "password"  # noqa: S105
+    res = client.post("/auth/register", json={"email": email, "password": pwd})
+    assert res.is_success
+    res = client.post("/auth/jwt/login", data={"username": email, "password": pwd})
+    assert res.is_success
+    auth = {"Authorization": f"Bearer {res.json()['access_token']}"}
+    res = client.get("/user/me", headers=auth)
+    assert res.is_success
+
+    u = UserRead.model_validate(res.json())
+    first_id = u.id
+    assert u.email == email
+    assert u.display_name is None
+    assert u.profile is None
+    assert u.avatar_url is None
+
+    res = client.patch(
+        "/user/me",
+        json={"display_name": "test"},
+        headers=auth,
+    )
+    assert res.is_success
+    u = UserRead.model_validate(res.json())
+    assert u.display_name == "test"
+    assert u.profile is None
+    assert u.avatar_url is None
+    assert u.id == first_id
+
+    res = client.patch(
+        "/user/me",
+        json={"username": "ididid"},
+        headers=auth,
+    )
+    assert res.is_success
+    u = UserRead.model_validate(res.json())
+    assert u.display_name == "test"
+    assert u.profile is None
+    assert u.avatar_url is None
+    assert u.username == "ididid"
+
+    res = client.get("/user/me", headers=auth)
+    u = UserRead.model_validate(res.json())
+    assert u.display_name == "test"
+    assert u.profile is None
+    assert u.avatar_url is None
+    assert u.username == "ididid"

--- a/knowde/feature/user/schema.py
+++ b/knowde/feature/user/schema.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from typing import Self
 
 from fastapi_users import schemas
-from pydantic import Field
 
 from knowde.feature.user import CommonSchema
 from knowde.shared.labels.user import LUser
@@ -18,7 +17,6 @@ class UserRead(CommonSchema, schemas.BaseUser[str]):
     """読み取り."""
 
     # CommonSchemaにまとめたかったが、BaseUserのoverrideに効かないくさい
-    id: str | None = Field(default=None, pattern=r"^[^-]*$")
     created: datetime
 
     @classmethod
@@ -38,5 +36,3 @@ class UserRead(CommonSchema, schemas.BaseUser[str]):
 
 class UserUpdate(CommonSchema, schemas.BaseUserUpdate):
     """更新."""
-
-    id: str | None = Field(default=None, pattern=r"^[^-]*$")

--- a/knowde/shared/labels/user.py
+++ b/knowde/shared/labels/user.py
@@ -42,6 +42,6 @@ class LUser(AsyncStructuredNode):
     display_name = StringProperty(default=None, max_length=LEN_DISPLAY_NAME)
     profile = StringProperty(default=None, max_length=LEN_PROFILE)
     avatar_url = StringProperty(default=None)
-
+    username = StringProperty(default=None, pattern=r"^[^-]*$")
     # oauth
     accounts = RelationshipTo(LAccount, "OAUTH")


### PR DESCRIPTION
idを変更できるようにしようと思ってたけど、fastapi-usersでは user/me patch でのidの変更を禁止していた
代わりにuserが定義できるidを username として フィールドに追加する
username検索でも userが検索できるようにする